### PR TITLE
Remove deprecated syncdb command from make install

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -1,4 +1,8 @@
-# VERSION=1.0.0
+# VERSION=1.0.1
+
+# CHANGES:
+# 1.0.1 - 2016-05-02 - Remove deprecated syncdb command from make install
+
 VE ?= ./ve
 MANAGE ?= ./manage.py
 FLAKE8 ?= $(VE)/bin/flake8

--- a/django.mk
+++ b/django.mk
@@ -75,7 +75,6 @@ rebase:
 # to run it after that, though.
 install: jenkins
 	createdb $(APP)
-	$(MANAGE) syncdb --noinput
 	make migrate
 
 .PHONY: jenkins test flake8 runserver migrate check shell clean pull rebase install


### PR DESCRIPTION
This was removed in django 1.9:
https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9