### PR TITLE
Don't hardcode hugo location

### DIFF
--- a/hugo.mk
+++ b/hugo.mk
@@ -1,5 +1,5 @@
 # VERSION=1.0.0
-HUGO ?= /usr/local/bin/hugo
+HUGO ?= `which hugo`
 S3CMD ?= s3cmd
 PUBLIC ?= public
 DRAFT_FLAGS ?= --buildDrafts --verboseLog=true -v


### PR DESCRIPTION
I'm open to alternatives here if someone has another idea, but I keep having to change this in my local makefile, since I install go packages in my user directory, so I have hugo installed at `/home/nik/gocode/bin/hugo`. Using `which` should work in both cases, searching PATH for the first match.