### PR TITLE
Fix eslint path

### DIFF
--- a/js.mk
+++ b/js.mk
@@ -5,7 +5,7 @@ JS_FILES ?= media/js
 
 NODE_MODULES ?= ./node_modules
 JS_SENTINAL ?= $(NODE_MODULES)/sentinal
-ESLINT ?= $(NODE_MODULES)/eslint/bin/eslint
+ESLINT ?= $(NODE_MODULES)/.bin/eslint
 
 $(JS_SENTINAL): package.json
 	rm -rf $(NODE_MODULES)


### PR DESCRIPTION
eslint installs to `node_modules/.bin/eslint` and
`node_modules/eslint/bin/eslint.js`