### PR TITLE
remove requirement to use local PyPI mirror

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,6 @@ Optional:
 * `SYS_PYTHON`, system python, default `python`
 * `PIP`, pip command, default `$(VE)/bin/pip`
 * `PY_SENTINAL`, python sentinal location, default `$(VE)/sentinal`
-* `PYPI_URL`, pypi mirror url, default `https://pypi.ccnmtl.columbia.edu/`
 * `WHEEL_VERSION`, version of python wheel library to install, default `0.24.0`
 * `VIRTUALENV`, location of embedded virtualenv.py, default `virtualenv.py`
 * `SUPPORT_DIR`, directory with support librarires, default `requirements/virtualenv_support/`

--- a/django.mk
+++ b/django.mk
@@ -1,6 +1,7 @@
 # VERSION=1.1.0
 
 # CHANGES:
+# 1.3.0 - 2017-06-05 - pypi location is not needed anymore
 # 1.2.0 - 2016-12-15 - bump wheel version to 0.29
 # 1.1.0 - 2016-11-08 - run flake8 tests before unit tests
 # 1.0.1 - 2016-05-02 - Remove deprecated syncdb command from make install
@@ -12,7 +13,6 @@ REQUIREMENTS ?= requirements.txt
 SYS_PYTHON ?= python
 PIP ?= $(VE)/bin/pip
 PY_SENTINAL ?= $(VE)/sentinal
-PYPI_URL ?= https://pypi.ccnmtl.columbia.edu/
 WHEEL_VERSION ?= 0.29.0
 VIRTUALENV ?= virtualenv.py
 SUPPORT_DIR ?= requirements/virtualenv_support/
@@ -26,8 +26,8 @@ jenkins: check flake8 test eslint
 $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)
 	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
-	$(PIP) install --index-url=$(PYPI_URL) wheel==$(WHEEL_VERSION)
-	$(PIP) install --use-wheel --no-deps --index-url=$(PYPI_URL) --requirement $(REQUIREMENTS)
+	$(PIP) install wheel==$(WHEEL_VERSION)
+	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS)
 	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)
 	touch $@
 


### PR DESCRIPTION
Individual `requirements.txt` files can still (and all of ours do) start
with `--index-url https://pypi....` to specify the pypi mirror to use.

The commandline arguments in here just force it even if it isn't
specified there. That was how we did things at first, before putting it
into all the `requirements.txt`.

Now, since PyPI has proven itself a bit more reliable and most of our
apps actually don't use any of the custom packages that need to keep in
our own index, I'm inclined towards allowing applications to use the
main PyPI rather than forcing our local mirror on them (it will also
allow us to use a more general service like Doppins to do update PRs and
let us simplify the CTL Archer setup). This change is the first step to
doing that. Once it is out, we can go repo by repo and point them at the
main PyPI mirror.