### PR TITLE
Exclude migrations files from flake8 checking

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -45,7 +45,7 @@ bandit: $(PY_SENTINAL)
 	$(BANDIT) --ini ./.bandit -r $(PY_DIRS)
 
 flake8: $(PY_SENTINAL)
-	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY)
+	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY) --exclude=*/migrations/*.py
 
 runserver: check
 	$(MANAGE) runserver $(INTERFACE):$(RUNSERVER_PORT)


### PR DESCRIPTION
I'm just tired of addressing the 80-column limit rule for automatically generated migrations files. I don't think it's necessary to do flake8 checking on migrations files unless they're hand-written.