### PR TITLE
django.mk use python 3 by default

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -1,6 +1,7 @@
 # VERSION=1.6.0
 
 # CHANGES:
+# 1.7.0 - TBA        - Now using python 3 by default
 # 1.6.0 - 2017-09-05 - add bandit secure analysis configuration
 # 1.5.0 - 2017-08-24 - remove jshint/jscs in favor of eslint
 # 1.4.0 - 2017-06-06 - backout the switch to eslint. that's not really ready yet.
@@ -14,7 +15,7 @@ MANAGE ?= ./manage.py
 FLAKE8 ?= $(VE)/bin/flake8
 BANDIT ?= $(VE)/bin/bandit
 REQUIREMENTS ?= requirements.txt
-SYS_PYTHON ?= python
+SYS_PYTHON ?= python3
 PIP ?= $(VE)/bin/pip
 PY_SENTINAL ?= $(VE)/sentinal
 WHEEL_VERSION ?= 0.30.0
@@ -31,7 +32,7 @@ $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)
 	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
 	$(PIP) install wheel==$(WHEEL_VERSION)
-	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS)
+	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
 	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)
 	touch $@
 


### PR DESCRIPTION
I've also added the --no-binary cryptography option, because we've seen
problems when this package isn't built from source.