### PR TITLE
django.mk: remove virtualenv.py

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -12,28 +12,34 @@
 
 VE ?= ./ve
 MANAGE ?= ./manage.py
-FLAKE8 ?= $(VE)/bin/flake8
-BANDIT ?= $(VE)/bin/bandit
 REQUIREMENTS ?= requirements.txt
 SYS_PYTHON ?= python3
-PIP ?= $(VE)/bin/pip
 PY_SENTINAL ?= $(VE)/sentinal
 WHEEL_VERSION ?= 0.31.0
-VIRTUALENV ?= virtualenv.py
-SUPPORT_DIR ?= requirements/virtualenv_support/
 MAX_COMPLEXITY ?= 10
 INTERFACE ?= localhost
 RUNSERVER_PORT ?= 8000
 PY_DIRS ?= $(APP)
 
+# Travis has issues here. See:
+# https://github.com/travis-ci/travis-ci/issues/9524
+ifeq ($(TRAVIS),true)
+	BANDIT ?= bandit
+	FLAKE8 ?= flake8
+	PIP ?= pip
+else
+	BANDIT ?= $(VE)/bin/bandit
+	FLAKE8 ?= $(VE)/bin/flake8
+	PIP ?= $(VE)/bin/pip
+endif
+
 jenkins: check flake8 test eslint bandit
 
-$(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
+$(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV)
 	rm -rf $(VE)
-	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
+	$(SYS_PYTHON) -m venv $(VE)
 	$(PIP) install wheel==$(WHEEL_VERSION)
 	$(PIP) install --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
-	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)
 	touch $@
 
 test: $(PY_SENTINAL)

--- a/django.mk
+++ b/django.mk
@@ -2,6 +2,8 @@
 
 # CHANGES:
 # 1.7.0 - TBA        - Now using python 3 by default
+#                    - Removed virtualenv.py in favor of python 3's
+#                      builtin venv capability.
 # 1.6.0 - 2017-09-05 - add bandit secure analysis configuration
 # 1.5.0 - 2017-08-24 - remove jshint/jscs in favor of eslint
 # 1.4.0 - 2017-06-06 - backout the switch to eslint. that's not really ready yet.


### PR DESCRIPTION
This changes the bootstrap script to call `python3 -m venv` instead of
`python virtualenv.py`.

There was one hiccup along the way: travis doesn't include the expected
symlinks in `./ve/bin/`.. I'm not sure why.
https://docs.python.org/3/library/venv.html

This is specific to travis, and should work everywhere else, so I've
added a conditional in here for travis.
https://github.com/travis-ci/travis-ci/issues/9524