### PR TITLE
Scaffolding to allow global flake8 ignores

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -57,7 +57,7 @@ bandit: $(PY_SENTINAL)
 	$(BANDIT) --ini ./.bandit -r $(PY_DIRS)
 
 flake8: $(PY_SENTINAL)
-	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY) --exclude=*/migrations/*.py
+	$(FLAKE8) $(PY_DIRS) --max-complexity=$(MAX_COMPLEXITY) --exclude=*/migrations/*.py --extend-ignore=$(FLAKE8_IGNORE)
 
 runserver: check
 	$(MANAGE) runserver $(INTERFACE):$(RUNSERVER_PORT)


### PR DESCRIPTION
Adding --extend-ignore to base flake8 configuration. Setting `FLAKE8_IGNORE` in the base Makefile will allow global ignores.

See here for the motivation: https://github.com/ccnmtl/mediathread/pull/1869/commits/6662ca037fcdd0ea2a1fdca0394513c939a002bd