### PR TITLE
Remove eslint from `make jenkins` target

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -34,7 +34,7 @@ FLAKE8 ?= $(VE)/bin/flake8
 PIP ?= $(VE)/bin/pip
 COVERAGE ?= $(VE)/bin/coverage
 
-jenkins: check flake8 test bandit eslint
+jenkins: check flake8 test bandit
 
 $(PY_SENTINAL): $(REQUIREMENTS)
 	rm -rf $(VE)


### PR DESCRIPTION
The `eslint` target isn't defined in this makefile, as it's not really part of Django. I think this should be handled elsewhere.