### PR TITLE
npm: Use --include=dev instead of --also=dev

### DIFF
--- a/js.mk
+++ b/js.mk
@@ -23,7 +23,7 @@ NODE_MODULES ?= ./node_modules
 JS_SENTINAL ?= $(NODE_MODULES)/sentinal
 ESLINT ?= $(NODE_MODULES)/.bin/eslint
 
-NPM_OPTS = --also=dev
+NPM_OPTS = --include=dev
 
 ifeq ($(ENVIRONMENT),production)
 	NPM_OPTS = --only=prod


### PR DESCRIPTION
Fixes this warning on npm 9.5.0:
```
npm WARN config also Please use --include=dev instead.
```