### PR TITLE
django.mk: Remove coverage tool

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -33,7 +33,6 @@ PY_DIRS ?= $(APP)
 BANDIT ?= $(VE)/bin/bandit
 FLAKE8 ?= $(VE)/bin/flake8
 PIP ?= $(VE)/bin/pip
-COVERAGE ?= $(VE)/bin/coverage
 
 jenkins: check flake8 test bandit
 
@@ -47,8 +46,7 @@ $(PY_SENTINAL): $(REQUIREMENTS)
 	touch $@
 
 test: $(PY_SENTINAL)
-	$(COVERAGE) run --source='.' --omit=$(VE)/* $(MANAGE) test $(PY_DIRS)
-	$(COVERAGE) xml -o reports/coverage.xml
+	$(MANAGE) test $(PY_DIRS)
 
 parallel-tests: $(PY_SENTINAL)
 	$(MANAGE) test --parallel
@@ -76,7 +74,6 @@ clean:
 	rm -rf media/CACHE
 	rm -rf reports
 	rm -f celerybeat-schedule
-	rm -f .coverage
 	rm -rf node_modules
 	find . -name '*.pyc' -exec rm {} \;
 


### PR DESCRIPTION
We don't really use this tool in practice, and I don't really find automated test coverage reports that useful for now. It only has the ability to give a very rough view of test coverage. It's better to focus on just writing good quality tests.

So I'm removing this in the interest of getting rid of an unnecessary package dependency in our stack.