### PR TITLE
js.mk: don't fail when sentinal is not created

### DIFF
--- a/js.mk
+++ b/js.mk
@@ -35,7 +35,7 @@ endif
 $(JS_SENTINAL): package.json
 	rm -rf $(NODE_MODULES)
 	npm install $(NPM_OPTS)
-	touch $(JS_SENTINAL)
+	[ -d $(NODE_MODULES) ] && touch $(JS_SENTINAL)
 
 eslint: $(JS_SENTINAL)
 	$(ESLINT) $(JS_FILES)


### PR DESCRIPTION
Some projects don't have any npm dependencies other than devDependencies, and so a node_modules dir is not created in production. This causes the build process to fail in newer versions of node, but it doesn't need to fail in that situation.